### PR TITLE
Adding a new cluster in us-east-2 region

### DIFF
--- a/clusters/cluster-us.yaml
+++ b/clusters/cluster-us.yaml
@@ -1,0 +1,134 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    ccm: external
+    csi: external
+    k8gb: enabled
+    test-gslb: create
+    nginx: create
+    k8gbClusterGeoTag: us-east-2
+  name: cluster-us
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: cluster-us-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSCluster
+    name: cluster-us
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSCluster
+metadata:
+  name: cluster-us
+  namespace: default
+  annotations:
+    aws.cluster.x-k8s.io/external-resource-gc: "true"
+spec:
+  region: us-east-2
+  sshKeyName: default
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: cluster-us-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data.local_hostname }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+        name: '{{ ds.meta_data.local_hostname }}'
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: AWSMachineTemplate
+      name: cluster-us-control-plane
+  replicas: 1
+  version: v1.27.0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: cluster-us-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: t3.medium
+      sshKeyName: default
+      spotMarketOptions:
+        maxPrice: "0.035"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: cluster-us-md-0
+  namespace: default
+spec:
+  clusterName: cluster-us
+  replicas: 1
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: cluster-us-md-0
+      clusterName: cluster-us
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSMachineTemplate
+        name: cluster-us-md-0
+      version: v1.27.0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: cluster-us-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: t3.medium
+      sshKeyName: default
+      spotMarketOptions:
+        maxPrice: "0.035"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: cluster-us-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data.local_hostname }}'

--- a/clusters/k8gb.yaml
+++ b/clusters/k8gb.yaml
@@ -22,7 +22,7 @@ spec:
       - "169.254.169.253" # use this DNS server as a main resolver to enable cross k8gb DNS based communication (DNS server for EC2)
       clusterGeoTag: "{{ .Cluster.metadata.labels.k8gbClusterGeoTag }}"
       # comma-separated list of external gslb geo tags to pair with
-      extGslbClustersGeoTags: "eu-west-2,todo"
+      extGslbClustersGeoTags: "eu-west-2,us-east-2"
 
     route53:
       enabled: true


### PR DESCRIPTION
based on the labels:
```
    ccm: external
    csi: external
    k8gb: enabled
    test-gslb: create
    nginx: create
    k8gbClusterGeoTag: us-east-2
```
it will get the cloud provider for aws, csi, cillium as cni, k8gb controller (with own coredns&externaldns), nginx ingress controller and test app - podinfo configured with a right geotag as a custom message.

This is done by `ClusterResourceSet` and `HelmChartProxy` CRs in the `/clusters` dir.